### PR TITLE
Feature / Support custom encryption keys - VGgJZ55T

### DIFF
--- a/lib/utils/cryptographer.js
+++ b/lib/utils/cryptographer.js
@@ -15,10 +15,11 @@ class Cryptographer {
    * Encrypt the given string
    *
    * @param  {string} input
+   * @param  {string} [key] Encryption key. Default: process.env.APP_KEY
    * @return {Promise}
    */
-  static encrypt (input) {
-    const cipher = crypto.createCipher('aes-256-cbc', process.env.APP_KEY)
+  static encrypt (input, key) {
+    const cipher = crypto.createCipher('aes-256-cbc', key || process.env.APP_KEY)
 
     if (/^[0-9a-f]{32,}$/g.test(input)) {
       return Promise.resolve(input)
@@ -44,10 +45,11 @@ class Cryptographer {
    * Decript the given string
    *
    * @param  {string} input Encrypted string
+   * @param  {string} [key] Encryption key. Default: process.env.APP_KEY
    * @return {Promise}
    */
-  static decrypt (input) {
-    const decipher = crypto.createDecipher('aes-256-cbc', process.env.APP_KEY)
+  static decrypt (input, key) {
+    const decipher = crypto.createDecipher('aes-256-cbc', key || process.env.APP_KEY)
 
     return new Promise((resolve, reject) => {
       let decrypted = ''


### PR DESCRIPTION
Allows the caller to choose which encryption key is going to be used whenever encrypting something.
This allow the application to use different keys whenever necessary. Example: to have a different key for data transport.

```
Cryptographer.encrypt('my-string') // Will use process.env.APP_KEY as the encryption key
Cryptographer.encrypt('my-string', 'SECRET') // Will use 'SECRET' as the encryption key
```

